### PR TITLE
geom_alt props

### DIFF
--- a/data/421/179/001/421179001.geojson
+++ b/data/421/179/001/421179001.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"TD",
     "wof:created":1459009201,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c58d52ad3f8c7aca7b0b661b1df7208d",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":421179001,
-    "wof:lastmodified":1566653798,
+    "wof:lastmodified":1582346990,
     "wof:name":"Ouara",
     "wof:parent_id":85678463,
     "wof:placetype":"county",

--- a/data/421/193/929/421193929.geojson
+++ b/data/421/193/929/421193929.geojson
@@ -440,6 +440,9 @@
     },
     "wof:country":"TD",
     "wof:created":1459009787,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6165c2d1d7814acfb37a5ce1599d257c",
     "wof:hierarchy":[
         {
@@ -450,7 +453,7 @@
         }
     ],
     "wof:id":421193929,
-    "wof:lastmodified":1566653797,
+    "wof:lastmodified":1582346990,
     "wof:name":"N'Djamena",
     "wof:parent_id":85678491,
     "wof:placetype":"county",

--- a/data/856/323/25/85632325.geojson
+++ b/data/856/323/25/85632325.geojson
@@ -954,8 +954,7 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "meso",
-        "naturalearth"
+        "meso"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"wk",
@@ -1031,7 +1030,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1582346978,
+    "wof:lastmodified":1583226551,
     "wof:name":"Chad",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/323/25/85632325.geojson
+++ b/data/856/323/25/85632325.geojson
@@ -954,7 +954,8 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "meso"
+        "meso",
+        "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"wk",
@@ -1009,6 +1010,11 @@
     },
     "wof:country":"TD",
     "wof:country_alpha3":"TCD",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "meso",
+        "naturalearth"
+    ],
     "wof:geomhash":"19c07f58dbd9d17181d351e4270032ca",
     "wof:hierarchy":[
         {
@@ -1025,7 +1031,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1566652989,
+    "wof:lastmodified":1582346978,
     "wof:name":"Chad",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/784/35/85678435.geojson
+++ b/data/856/784/35/85678435.geojson
@@ -210,6 +210,9 @@
         "wd:id":"Q1042437"
     },
     "wof:country":"TD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"512b7eccc70997330f93d207245e5085",
     "wof:hierarchy":[
         {
@@ -227,7 +230,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1566652992,
+    "wof:lastmodified":1582346980,
     "wof:name":"Hadjer-Lamis",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/784/39/85678439.geojson
+++ b/data/856/784/39/85678439.geojson
@@ -271,6 +271,9 @@
         "wk:page":"Kanem Region"
     },
     "wof:country":"TD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"efd64d7e1e8cd94a42ff50bed2401e1d",
     "wof:hierarchy":[
         {
@@ -288,7 +291,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1566652993,
+    "wof:lastmodified":1582346980,
     "wof:name":"Kanem",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/784/45/85678445.geojson
+++ b/data/856/784/45/85678445.geojson
@@ -270,6 +270,9 @@
         "wk:page":"Lac Region"
     },
     "wof:country":"TD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"add09bf8dd25ee7f5abc63e70eb8b957",
     "wof:hierarchy":[
         {
@@ -287,7 +290,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1566652992,
+    "wof:lastmodified":1582346980,
     "wof:name":"Lac",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/784/49/85678449.geojson
+++ b/data/856/784/49/85678449.geojson
@@ -276,6 +276,9 @@
         "wk:page":"Batha Region"
     },
     "wof:country":"TD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"efcd65f901ba70ea580addd50bc17e7e",
     "wof:hierarchy":[
         {
@@ -293,7 +296,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1566652994,
+    "wof:lastmodified":1582346980,
     "wof:name":"Batha",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/784/53/85678453.geojson
+++ b/data/856/784/53/85678453.geojson
@@ -268,6 +268,9 @@
         "wk:page":"Wadi Fira Region"
     },
     "wof:country":"TD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"216af0029c2bc2d6e9fb414b5bf5b026",
     "wof:hierarchy":[
         {
@@ -285,7 +288,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1566652993,
+    "wof:lastmodified":1582346980,
     "wof:name":"Wadi Fira",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/784/57/85678457.geojson
+++ b/data/856/784/57/85678457.geojson
@@ -284,6 +284,9 @@
         "wk:page":"Gu\u00e9ra Region"
     },
     "wof:country":"TD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c1e7b0915159932a01362791fd1d0853",
     "wof:hierarchy":[
         {
@@ -301,7 +304,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1566652991,
+    "wof:lastmodified":1582346980,
     "wof:name":"Gu\u00e9ra",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/784/63/85678463.geojson
+++ b/data/856/784/63/85678463.geojson
@@ -280,6 +280,9 @@
         "wk:page":"Ouadda\u00ef Region"
     },
     "wof:country":"TD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d0bede083dbadb4c8794c3fc983a7956",
     "wof:hierarchy":[
         {
@@ -297,7 +300,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1566652994,
+    "wof:lastmodified":1582346980,
     "wof:name":"Ouadda\u00ef",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/784/67/85678467.geojson
+++ b/data/856/784/67/85678467.geojson
@@ -283,6 +283,9 @@
         "wk:page":"Logone Occidental Region"
     },
     "wof:country":"TD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6659782781ce3ea002fd978df70b6878",
     "wof:hierarchy":[
         {
@@ -300,7 +303,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1566652992,
+    "wof:lastmodified":1582346980,
     "wof:name":"Logone Occidental",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/784/69/85678469.geojson
+++ b/data/856/784/69/85678469.geojson
@@ -270,6 +270,9 @@
         "wk:page":"Logone Oriental Region"
     },
     "wof:country":"TD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f571cc2475ec1ee33c3d0c6adf292276",
     "wof:hierarchy":[
         {
@@ -287,7 +290,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1566652992,
+    "wof:lastmodified":1582346980,
     "wof:name":"Logone Oriental",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/784/73/85678473.geojson
+++ b/data/856/784/73/85678473.geojson
@@ -279,6 +279,9 @@
         "wk:page":"Mayo-Kebbi Est Region"
     },
     "wof:country":"TD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"759e4d521156ce1c2a6dd14026b910ba",
     "wof:hierarchy":[
         {
@@ -296,7 +299,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1566652992,
+    "wof:lastmodified":1582346980,
     "wof:name":"Mayo Kebbi Est",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/784/77/85678477.geojson
+++ b/data/856/784/77/85678477.geojson
@@ -275,6 +275,9 @@
         "wk:page":"Tandjil\u00e9 Region"
     },
     "wof:country":"TD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"199f5c5a1154303b586e2efb3f29c6e7",
     "wof:hierarchy":[
         {
@@ -292,7 +295,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1566652994,
+    "wof:lastmodified":1582346980,
     "wof:name":"Tandjil\u00e9",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/784/83/85678483.geojson
+++ b/data/856/784/83/85678483.geojson
@@ -267,6 +267,9 @@
         "wd:id":"Q597410"
     },
     "wof:country":"TD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b86d3b1a6a5af3ac26d3f2255565f1ec",
     "wof:hierarchy":[
         {
@@ -284,7 +287,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1566652994,
+    "wof:lastmodified":1582346980,
     "wof:name":"Mandoul",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/784/87/85678487.geojson
+++ b/data/856/784/87/85678487.geojson
@@ -273,6 +273,9 @@
         "wk:page":"Salamat Region"
     },
     "wof:country":"TD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"64cedfe04d02b8f2bbf1cd1435326feb",
     "wof:hierarchy":[
         {
@@ -290,7 +293,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1566652993,
+    "wof:lastmodified":1582346980,
     "wof:name":"Salamat",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/784/91/85678491.geojson
+++ b/data/856/784/91/85678491.geojson
@@ -503,6 +503,9 @@
         890440301
     ],
     "wof:country":"TD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6165c2d1d7814acfb37a5ce1599d257c",
     "wof:hierarchy":[
         {
@@ -520,7 +523,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1566652993,
+    "wof:lastmodified":1582346980,
     "wof:name":"N'Djamena",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/784/95/85678495.geojson
+++ b/data/856/784/95/85678495.geojson
@@ -280,6 +280,9 @@
         "wk:page":"Mayo-Kebbi Ouest Region"
     },
     "wof:country":"TD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9e91eaca734fafc547c019db3ee2047b",
     "wof:hierarchy":[
         {
@@ -297,7 +300,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1566652991,
+    "wof:lastmodified":1582346980,
     "wof:name":"Mayo-Kebbi Ouest",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/785/01/85678501.geojson
+++ b/data/856/785/01/85678501.geojson
@@ -159,6 +159,9 @@
         "wd:id":"Q4272710"
     },
     "wof:country":"TD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"31f5b9c81b123f2183c9d4a08c2c6386",
     "wof:hierarchy":[
         {
@@ -176,7 +179,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1566652991,
+    "wof:lastmodified":1582346979,
     "wof:name":"Borkou",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/785/05/85678505.geojson
+++ b/data/856/785/05/85678505.geojson
@@ -151,6 +151,9 @@
         "iso:id":"TD-TI"
     },
     "wof:country":"TD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e7c5f873f0026460dc40b3f66c63d6fb",
     "wof:hierarchy":[
         {
@@ -168,7 +171,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1566652990,
+    "wof:lastmodified":1582346979,
     "wof:name":"Tibesti",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/785/13/85678513.geojson
+++ b/data/856/785/13/85678513.geojson
@@ -214,6 +214,9 @@
         "wd:id":"Q843975"
     },
     "wof:country":"TD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"adc53a677eca971b2cdda395daecc9cd",
     "wof:hierarchy":[
         {
@@ -231,7 +234,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1566652991,
+    "wof:lastmodified":1582346980,
     "wof:name":"Chari-Baguirmi",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/785/19/85678519.geojson
+++ b/data/856/785/19/85678519.geojson
@@ -231,6 +231,9 @@
         "wd:id":"Q803639"
     },
     "wof:country":"TD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"869d49062063a7c6b370407160dfa2ba",
     "wof:hierarchy":[
         {
@@ -248,7 +251,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1566652991,
+    "wof:lastmodified":1582346979,
     "wof:name":"Barh-El-Gazel",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/785/23/85678523.geojson
+++ b/data/856/785/23/85678523.geojson
@@ -433,6 +433,9 @@
         "wd:id":"Q359465"
     },
     "wof:country":"TD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"12eb0aa50c508a97629e23fff4bb0ef3",
     "wof:hierarchy":[
         {
@@ -450,7 +453,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1566652991,
+    "wof:lastmodified":1582346980,
     "wof:name":"Sila",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/785/27/85678527.geojson
+++ b/data/856/785/27/85678527.geojson
@@ -339,6 +339,9 @@
         "wd:id":"Q6927631"
     },
     "wof:country":"TD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4eac9fe78f78a688d65c7c0e0eb7741c",
     "wof:hierarchy":[
         {
@@ -356,7 +359,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1566652990,
+    "wof:lastmodified":1582346979,
     "wof:name":"Moyen-Chari",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/890/440/301/890440301.geojson
+++ b/data/890/440/301/890440301.geojson
@@ -582,6 +582,10 @@
     ],
     "wof:country":"TD",
     "wof:created":1469052270,
+    "wof:geom_alt":[
+        "unknown",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6165c2d1d7814acfb37a5ce1599d257c",
     "wof:hierarchy":[
         {
@@ -593,7 +597,7 @@
         }
     ],
     "wof:id":890440301,
-    "wof:lastmodified":1566653799,
+    "wof:lastmodified":1582346990,
     "wof:name":"N'Djamena",
     "wof:parent_id":421193929,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.