### PR TITLE
Name updates

### DIFF
--- a/data/856/323/25/85632325.geojson
+++ b/data/856/323/25/85632325.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":107.201934,
-    "geom:area_square_m":1275217817180.229492,
+    "geom:area_square_m":1275217818763.397461,
     "geom:bbox":"13.47,7.442975,24.000001,23.449228",
     "geom:latitude":15.375822,
     "geom:longitude":18.667944,
@@ -67,6 +67,9 @@
     "name:arg_x_preferred":[
         "Chad"
     ],
+    "name:ary_x_preferred":[
+        "\u062a\u0634\u0627\u062f"
+    ],
     "name:arz_x_preferred":[
         "\u062a\u0634\u0627\u062f"
     ],
@@ -90,6 +93,9 @@
     ],
     "name:bam_x_variant":[
         "Cadi"
+    ],
+    "name:ban_x_preferred":[
+        "Chad"
     ],
     "name:bar_x_preferred":[
         "Tschad"
@@ -173,6 +179,12 @@
     "name:dan_x_preferred":[
         "Tchad"
     ],
+    "name:deu_at_x_preferred":[
+        "Tschad"
+    ],
+    "name:deu_ch_x_preferred":[
+        "Tschad"
+    ],
     "name:deu_x_preferred":[
         "Tschad"
     ],
@@ -196,6 +208,12 @@
     ],
     "name:ell_x_preferred":[
         "\u03a4\u03c3\u03b1\u03bd\u03c4"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Chad"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Chad"
     ],
     "name:eng_x_preferred":[
         "Chad"
@@ -266,6 +284,9 @@
     ],
     "name:gag_x_preferred":[
         "\u00c7ad"
+    ],
+    "name:gcr_x_preferred":[
+        "Tchad"
     ],
     "name:gla_x_preferred":[
         "An t-Siad"
@@ -515,6 +536,12 @@
     "name:mlt_x_preferred":[
         "\u010aad"
     ],
+    "name:mon_x_preferred":[
+        "\u0427\u0430\u0434"
+    ],
+    "name:mri_x_preferred":[
+        "K\u0101ta"
+    ],
     "name:mrj_x_preferred":[
         "\u0427\u0430\u0434"
     ],
@@ -624,6 +651,9 @@
     "name:pol_x_preferred":[
         "Czad"
     ],
+    "name:por_br_x_preferred":[
+        "Chade"
+    ],
     "name:por_x_preferred":[
         "Chade"
     ],
@@ -687,6 +717,9 @@
     "name:sme_x_variant":[
         "T\u010dad"
     ],
+    "name:smo_x_preferred":[
+        "Chad"
+    ],
     "name:sna_x_preferred":[
         "Chad"
     ],
@@ -717,6 +750,12 @@
     "name:srd_x_preferred":[
         "Chad"
     ],
+    "name:srp_ec_x_preferred":[
+        "\u0427\u0430\u0434"
+    ],
+    "name:srp_el_x_preferred":[
+        "\u010cad"
+    ],
     "name:srp_x_preferred":[
         "\u0427\u0430\u0434"
     ],
@@ -740,6 +779,9 @@
     ],
     "name:szl_x_preferred":[
         "Czad"
+    ],
+    "name:szy_x_preferred":[
+        "Chad"
     ],
     "name:tam_x_preferred":[
         "\u0b9a\u0bbe\u0b9f\u0bcd"
@@ -857,6 +899,9 @@
     ],
     "name:yue_x_preferred":[
         "\u4e4d\u5f97"
+    ],
+    "name:zea_x_preferred":[
+        "Tsjaod"
     ],
     "name:zha_x_preferred":[
         "Chad"
@@ -1031,7 +1076,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1583797437,
+    "wof:lastmodified":1587428033,
     "wof:name":"Chad",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/890/444/443/890444443.geojson
+++ b/data/890/444/443/890444443.geojson
@@ -116,7 +116,8 @@
         "\u0baa\u0bcb\u0bb2\u0bcd"
     ],
     "name:tam_x_variant":[
-        "\u0baa\u0bcb\u0bb2\u0bcd "
+        "\u0baa\u0bcb\u0bb2\u0bcd ",
+        "\u0baa\u0bcb\u0bb2\u0bcd"
     ],
     "name:tel_x_preferred":[
         "\u0c2c\u0c4b\u0c32\u0c4d"
@@ -137,7 +138,8 @@
         "\u0628\u0648\u0644 \u060c \u0686\u0627\u0688"
     ],
     "name:urd_x_variant":[
-        "\u0628\u0648\u0644 "
+        "\u0628\u0648\u0644 ",
+        "\u0628\u0648\u0644"
     ],
     "name:vie_x_preferred":[
         "Bol"
@@ -246,8 +248,8 @@
     "wof:belongsto":[
         102191573,
         85632325,
-        85678445,
-        1091901265
+        1091901265,
+        85678445
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -270,7 +272,7 @@
         }
     ],
     "wof:id":890444443,
-    "wof:lastmodified":1566653801,
+    "wof:lastmodified":1587161842,
     "wof:name":"Bol",
     "wof:parent_id":1091901265,
     "wof:placetype":"locality",

--- a/data/890/444/443/890444443.geojson
+++ b/data/890/444/443/890444443.geojson
@@ -116,7 +116,7 @@
         "\u0baa\u0bcb\u0bb2\u0bcd"
     ],
     "name:tam_x_variant":[
-        "\u0baa\u0bcb\u0bb2\u0bcd ",
+        "\u0baa\u0bcb\u0bb2\u0bcd",
         "\u0baa\u0bcb\u0bb2\u0bcd"
     ],
     "name:tel_x_preferred":[
@@ -138,7 +138,7 @@
         "\u0628\u0648\u0644 \u060c \u0686\u0627\u0688"
     ],
     "name:urd_x_variant":[
-        "\u0628\u0648\u0644 ",
+        "\u0628\u0648\u0644",
         "\u0628\u0648\u0644"
     ],
     "name:vie_x_preferred":[
@@ -272,7 +272,7 @@
         }
     ],
     "wof:id":890444443,
-    "wof:lastmodified":1587161842,
+    "wof:lastmodified":1587163142,
     "wof:name":"Bol",
     "wof:parent_id":1091901265,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.