### PR TITLE
WIP: Move centroids inside geometries

### DIFF
--- a/data/110/880/853/5/1108808535.geojson
+++ b/data/110/880/853/5/1108808535.geojson
@@ -19,10 +19,12 @@
     "label:eng_x_preferred_shortcode":[
         "EE"
     ],
-    "lbl:latitude":17.781345,
-    "lbl:longitude":23.14484,
+    "lbl:latitude":16.233445,
+    "lbl:longitude":23.108125,
     "lbl:min_zoom":8.0,
     "meso:name_local":"Ennedi Est",
+    "mps:latitude":16.233445,
+    "mps:longitude":23.108125,
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:max_zoom":11.0,
@@ -147,7 +149,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1614893135,
+    "wof:lastmodified":1694320549,
     "wof:name":"Ennedi Est",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/785/05/85678505.geojson
+++ b/data/856/785/05/85678505.geojson
@@ -19,12 +19,12 @@
     "label:eng_x_preferred_shortcode":[
         "TI"
     ],
-    "lbl:latitude":20.60618,
-    "lbl:longitude":17.765288,
+    "lbl:latitude":21.685327,
+    "lbl:longitude":16.638376,
     "lbl:min_zoom":8.0,
     "meso:name_local":"Tibesti",
-    "mps:latitude":21.674498,
-    "mps:longitude":16.643964,
+    "mps:latitude":21.685327,
+    "mps:longitude":16.638376,
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:max_zoom":11.0,
@@ -181,7 +181,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1636501289,
+    "wof:lastmodified":1694320549,
     "wof:name":"Tibesti",
     "wof:parent_id":85632325,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2159.

This PR updates records with label centroids that fall outside of a geometry. The new label centroid comes from Mapshaper, the `src:lbl_centroid` property has been updated, too.

This PR will require PIP work before merge.