### PR TITLE
td concordances, placetype local, and more

### DIFF
--- a/data/109/189/982/1/1091899821.geojson
+++ b/data/109/189/982/1/1091899821.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.159601,
-    "geom:area_square_m":1953691453.883871,
+    "geom:area_square_m":1953691455.67623,
     "geom:bbox":"16.656466,7.921171,17.198166,8.413971",
     "geom:latitude":8.121874,
     "geom:longitude":16.887264,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.LR.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892101,
-    "wof:geomhash":"ea6d4a892177b74c94ead900c72b3f43",
+    "wof:geomhash":"c2c98c84cf3a43105b8a159cfb9cd432",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091899821,
-    "wof:lastmodified":1627522812,
+    "wof:lastmodified":1695886513,
     "wof:name":"Kouh Ouest",
     "wof:parent_id":85678469,
     "wof:placetype":"county",

--- a/data/109/189/986/1/1091899861.geojson
+++ b/data/109/189/986/1/1091899861.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.369932,
-    "geom:area_square_m":4530297859.063642,
+    "geom:area_square_m":4530294100.877817,
     "geom:bbox":"16.279266,7.542908,17.271532,8.468771",
     "geom:latitude":7.949332,
     "geom:longitude":16.67886,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.LR.NP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892103,
-    "wof:geomhash":"490fed012aa6a34aceb81cc78449f72c",
+    "wof:geomhash":"a86999a4fc030575ead3c99f2906ad07",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091899861,
-    "wof:lastmodified":1627522812,
+    "wof:lastmodified":1695886513,
     "wof:name":"La Nya Pende",
     "wof:parent_id":85678469,
     "wof:placetype":"county",

--- a/data/109/189/989/1/1091899891.geojson
+++ b/data/109/189/989/1/1091899891.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.133374,
-    "geom:area_square_m":1631538105.21795,
+    "geom:area_square_m":1631538106.764835,
     "geom:bbox":"16.812966,8.134371,17.291566,8.625871",
     "geom:latitude":8.387699,
     "geom:longitude":17.051056,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.LR.KE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892104,
-    "wof:geomhash":"a53e5dae3c112a803eefda6a6905e58e",
+    "wof:geomhash":"655ce3f508a018857445bca712f6d642",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091899891,
-    "wof:lastmodified":1627522812,
+    "wof:lastmodified":1695886513,
     "wof:name":"Kouh Est",
     "wof:parent_id":85678469,
     "wof:placetype":"county",

--- a/data/109/189/991/1/1091899911.geojson
+++ b/data/109/189/991/1/1091899911.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.800585,
-    "geom:area_square_m":9802443495.311432,
+    "geom:area_square_m":9802435649.521391,
     "geom:bbox":"15.242123,7.457886,16.450166,8.644371",
     "geom:latitude":8.021041,
     "geom:longitude":15.89938,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.LR.ML"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892106,
-    "wof:geomhash":"b71bcf872364811cd358fb0e10328900",
+    "wof:geomhash":"9ead839709cf3fd23ba7c012539c1883",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091899911,
-    "wof:lastmodified":1627522813,
+    "wof:lastmodified":1695886514,
     "wof:name":"Monts de Lam",
     "wof:parent_id":85678469,
     "wof:placetype":"county",

--- a/data/109/189/994/5/1091899945.geojson
+++ b/data/109/189/994/5/1091899945.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.451941,
-    "geom:area_square_m":5528119072.525143,
+    "geom:area_square_m":5528119072.525135,
     "geom:bbox":"18.1231663397,8.02111816406,19.0848776453,8.88167136831",
     "geom:latitude":8.416542,
     "geom:longitude":18.53985,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"TD.MO.GR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892108,
-    "wof:geomhash":"cf13adda998b2cc60fc8ccc0fb26ccea",
+    "wof:geomhash":"3f628292106165f6c54dab3b2efd869a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1091899945,
-    "wof:lastmodified":1566653726,
+    "wof:lastmodified":1695886485,
     "wof:name":"Grande Sido",
     "wof:parent_id":85678527,
     "wof:placetype":"county",

--- a/data/109/189/997/5/1091899975.geojson
+++ b/data/109/189/997/5/1091899975.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.159906,
-    "geom:area_square_m":1954814721.397656,
+    "geom:area_square_m":1954814721.397646,
     "geom:bbox":"17.0489663397,8.28517136831,17.5195663397,8.93107136831",
     "geom:latitude":8.644774,
     "geom:longitude":17.279487,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"TD.MA.MC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892110,
-    "wof:geomhash":"cfa8359bdf4b55167dc1c838d7fd207e",
+    "wof:geomhash":"d49f9b57b63505f2ecf4914866147a68",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1091899975,
-    "wof:lastmodified":1566653725,
+    "wof:lastmodified":1695886485,
     "wof:name":"Mandoul Occidental",
     "wof:parent_id":85678483,
     "wof:placetype":"county",

--- a/data/109/190/000/3/1091900003.geojson
+++ b/data/109/190/000/3/1091900003.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.688757,
-    "geom:area_square_m":8426804843.914153,
+    "geom:area_square_m":8426804843.914179,
     "geom:bbox":"17.1138663397,7.82635570698,18.2132333887,8.95827136831",
     "geom:latitude":8.324329,
     "geom:longitude":17.716859,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"TD.MA.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892111,
-    "wof:geomhash":"2f730be017d00d85abcde31358ad50d5",
+    "wof:geomhash":"d6ed5843807de30236472dc1b3adfd22",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1091900003,
-    "wof:lastmodified":1566653729,
+    "wof:lastmodified":1695886485,
     "wof:name":"Barh Sara",
     "wof:parent_id":85678483,
     "wof:placetype":"county",

--- a/data/109/190/003/1/1091900031.geojson
+++ b/data/109/190/003/1/1091900031.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.281137,
-    "geom:area_square_m":3436806270.747838,
+    "geom:area_square_m":3436806274.106877,
     "geom:bbox":"15.567366,8.239371,16.391866,8.986571",
     "geom:latitude":8.64491,
     "geom:longitude":15.961311,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.LO.LW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892113,
-    "wof:geomhash":"172f4ae9a5897c647e720fc99c51d979",
+    "wof:geomhash":"13f29ec6455aec05c3b43a4e38897a78",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091900031,
-    "wof:lastmodified":1627522812,
+    "wof:lastmodified":1695886513,
     "wof:name":"Lac Wey",
     "wof:parent_id":85678467,
     "wof:placetype":"county",

--- a/data/109/190/005/7/1091900057.geojson
+++ b/data/109/190/005/7/1091900057.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.21623,
-    "geom:area_square_m":2643115267.177524,
+    "geom:area_square_m":2643115269.770068,
     "geom:bbox":"15.287466,8.277471,15.781766,9.044671",
     "geom:latitude":8.676006,
     "geom:longitude":15.523151,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.LO.DJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892114,
-    "wof:geomhash":"7c79ad5d44f21e7feb08eadb441ef7ac",
+    "wof:geomhash":"02a1686fc60c83b1404999fbd1c120f2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091900057,
-    "wof:lastmodified":1627522811,
+    "wof:lastmodified":1695886512,
     "wof:name":"Dodje",
     "wof:parent_id":85678467,
     "wof:placetype":"county",

--- a/data/109/190/007/3/1091900073.geojson
+++ b/data/109/190/007/3/1091900073.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.218645,
-    "geom:area_square_m":2673404942.005991,
+    "geom:area_square_m":2673404944.594828,
     "geom:bbox":"16.336666,8.016771,16.849266,9.077371",
     "geom:latitude":8.56693,
     "geom:longitude":16.623565,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.LR.NY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892116,
-    "wof:geomhash":"59285066a2390306112f586ccb487386",
+    "wof:geomhash":"12f54305a4140d90f40481cecee6c019",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091900073,
-    "wof:lastmodified":1627522812,
+    "wof:lastmodified":1695886513,
     "wof:name":"La nya",
     "wof:parent_id":85678469,
     "wof:placetype":"county",

--- a/data/109/190/011/3/1091900113.geojson
+++ b/data/109/190/011/3/1091900113.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.09534,
-    "geom:area_square_m":1164488983.403075,
+    "geom:area_square_m":1164488984.584262,
     "geom:bbox":"15.572566,8.780471,16.210466,9.121771",
     "geom:latitude":8.96677,
     "geom:longitude":15.895121,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.LO.GN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892118,
-    "wof:geomhash":"73c3160cbffea29c72b2581af5f16294",
+    "wof:geomhash":"d85842b29203b8911e75f774ae5192c4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091900113,
-    "wof:lastmodified":1627522812,
+    "wof:lastmodified":1695886513,
     "wof:name":"Gueni",
     "wof:parent_id":85678467,
     "wof:placetype":"county",

--- a/data/109/190/015/7/1091900157.geojson
+++ b/data/109/190/015/7/1091900157.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.198641,
-    "geom:area_square_m":2426827435.045563,
+    "geom:area_square_m":2426827437.481108,
     "geom:bbox":"16.445266,8.575071,17.147966,9.138571",
     "geom:latitude":8.873867,
     "geom:longitude":16.894083,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.LR.PD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892119,
-    "wof:geomhash":"2ea5c5985f49881e402209f48ddf9f3a",
+    "wof:geomhash":"f8d262f51e96f146251a810cf947225e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091900157,
-    "wof:lastmodified":1627522812,
+    "wof:lastmodified":1695886513,
     "wof:name":"La Pende",
     "wof:parent_id":85678469,
     "wof:placetype":"county",

--- a/data/109/190/017/7/1091900177.geojson
+++ b/data/109/190/017/7/1091900177.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.138403,
-    "geom:area_square_m":1690513317.695534,
+    "geom:area_square_m":1690513317.695529,
     "geom:bbox":"16.1540663397,8.63467136831,16.6369663397,9.24427136831",
     "geom:latitude":8.954644,
     "geom:longitude":16.390483,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"TD.LO.NK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892121,
-    "wof:geomhash":"d280b98b244220d47b3de945a854896a",
+    "wof:geomhash":"b0d75c890055663520a45df7e2777c78",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1091900177,
-    "wof:lastmodified":1566653735,
+    "wof:lastmodified":1695886486,
     "wof:name":"Ngourkosso",
     "wof:parent_id":85678467,
     "wof:placetype":"county",

--- a/data/109/190/019/3/1091900193.geojson
+++ b/data/109/190/019/3/1091900193.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.581493,
-    "geom:area_square_m":7098595910.64784,
+    "geom:area_square_m":7098595910.647738,
     "geom:bbox":"17.0763663397,8.61217136831,18.1999663397,9.65127136831",
     "geom:latitude":9.156616,
     "geom:longitude":17.562494,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"TD.MA.MR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892122,
-    "wof:geomhash":"3193a8703b7c08bf2b776a2983b1c659",
+    "wof:geomhash":"fc902bbee9524ab3d8e15a489deb91a0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1091900193,
-    "wof:lastmodified":1566653735,
+    "wof:lastmodified":1695886486,
     "wof:name":"Mandoul Oriental",
     "wof:parent_id":85678483,
     "wof:placetype":"county",

--- a/data/109/190/023/7/1091900237.geojson
+++ b/data/109/190/023/7/1091900237.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.710074,
-    "geom:area_square_m":8669015646.399971,
+    "geom:area_square_m":8669009883.662296,
     "geom:bbox":"14.224487,8.430488,15.468566,9.698486",
     "geom:latitude":9.12461,
     "geom:longitude":14.940495,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.MW.MD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892129,
-    "wof:geomhash":"aafbdb8d4c8418bbd32df021c19b6ab3",
+    "wof:geomhash":"8f58901bf0e30ee68aacb9589f6cc996",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091900237,
-    "wof:lastmodified":1627522813,
+    "wof:lastmodified":1695886514,
     "wof:name":"Mayo Dallah",
     "wof:parent_id":85678495,
     "wof:placetype":"county",

--- a/data/109/190/027/1/1091900271.geojson
+++ b/data/109/190/027/1/1091900271.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.318202,
-    "geom:area_square_m":3882357358.051736,
+    "geom:area_square_m":3882357877.358825,
     "geom:bbox":"15.420966,9.010771,16.224766,9.724671",
     "geom:latitude":9.347766,
     "geom:longitude":15.789858,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.TA.TW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892130,
-    "wof:geomhash":"4f62ddba693c68099b9769fbd26a7a5e",
+    "wof:geomhash":"15645312a2589a6ae80628977283211f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091900271,
-    "wof:lastmodified":1627522813,
+    "wof:lastmodified":1695886514,
     "wof:name":"Tandjile Ouest",
     "wof:parent_id":85678477,
     "wof:placetype":"county",

--- a/data/109/190/031/1/1091900311.geojson
+++ b/data/109/190/031/1/1091900311.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.262494,
-    "geom:area_square_m":3200815055.120046,
+    "geom:area_square_m":3200815058.581123,
     "geom:bbox":"15.070766,9.207471,15.815666,9.852571",
     "geom:latitude":9.548407,
     "geom:longitude":15.410794,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.ME.KB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892132,
-    "wof:geomhash":"d58942f3f7821620d854521e8ee01999",
+    "wof:geomhash":"f7c8bb2b7966885c770f9dba39f02e90",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091900311,
-    "wof:lastmodified":1627522812,
+    "wof:lastmodified":1695886513,
     "wof:name":"La Kabbia",
     "wof:parent_id":85678473,
     "wof:placetype":"county",

--- a/data/109/190/035/7/1091900357.geojson
+++ b/data/109/190/035/7/1091900357.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.235449,
-    "geom:area_square_m":2868627579.58191,
+    "geom:area_square_m":2868627579.581938,
     "geom:bbox":"14.7211663397,9.56037136831,15.7654663397,9.98950195313",
     "geom:latitude":9.829312,
     "geom:longitude":15.172244,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"TD.ME.MI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892133,
-    "wof:geomhash":"ac87178e466bf6db1e20c5d844f91f64",
+    "wof:geomhash":"dc171bdd8fb47262517aa7543d741ede",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091900357,
-    "wof:lastmodified":1566653735,
+    "wof:lastmodified":1695886486,
     "wof:name":"Mont Illi",
     "wof:parent_id":85678473,
     "wof:placetype":"county",

--- a/data/109/190/039/9/1091900399.geojson
+++ b/data/109/190/039/9/1091900399.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.25022,
-    "geom:area_square_m":3050616530.036257,
+    "geom:area_square_m":3050616845.886843,
     "geom:bbox":"13.957092,9.362488,14.75293,9.871882",
     "geom:latitude":9.606947,
     "geom:longitude":14.372782,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.MW.LE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892135,
-    "wof:geomhash":"782b994f7d6bd02230eaf0195d240bdc",
+    "wof:geomhash":"1f11bc355337ed782daacb9581c34a55",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091900399,
-    "wof:lastmodified":1627522812,
+    "wof:lastmodified":1695886513,
     "wof:name":"Lac Lere",
     "wof:parent_id":85678495,
     "wof:placetype":"county",

--- a/data/109/190/043/5/1091900435.geojson
+++ b/data/109/190/043/5/1091900435.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.03171,
-    "geom:area_square_m":12577655300.650122,
+    "geom:area_square_m":12577655314.35816,
     "geom:bbox":"15.973566,9.046071,17.587966,10.264971",
     "geom:latitude":9.622659,
     "geom:longitude":16.723295,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.TA.TE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892136,
-    "wof:geomhash":"9ca10271b7ebb9db03b86f0651edd455",
+    "wof:geomhash":"0943a7d59fa8be5216a87c9c0006a37c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091900435,
-    "wof:lastmodified":1627522813,
+    "wof:lastmodified":1695886514,
     "wof:name":"Tandjile Est",
     "wof:parent_id":85678477,
     "wof:placetype":"county",

--- a/data/109/190/048/7/1091900487.geojson
+++ b/data/109/190/048/7/1091900487.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.508609,
-    "geom:area_square_m":18394153473.871365,
+    "geom:area_square_m":18394155396.216774,
     "geom:bbox":"17.381966,8.530071,19.125916,10.496971",
     "geom:latitude":9.564267,
     "geom:longitude":18.146632,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.MO.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892138,
-    "wof:geomhash":"829af37a3b99fdf09c82b23caa204787",
+    "wof:geomhash":"bbeb07c89e0924edbf79368fffaf130b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091900487,
-    "wof:lastmodified":1627522811,
+    "wof:lastmodified":1695886512,
     "wof:name":"Bahr Koh",
     "wof:parent_id":85678527,
     "wof:placetype":"county",

--- a/data/109/190/052/3/1091900523.geojson
+++ b/data/109/190/052/3/1091900523.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.463872,
-    "geom:area_square_m":17847251144.689911,
+    "geom:area_square_m":17847247147.739677,
     "geom:bbox":"18.295366,8.987022,19.990258,10.587971",
     "geom:latitude":9.599945,
     "geom:longitude":19.202042,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.MO.LI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892139,
-    "wof:geomhash":"14a299bfc5a41d81ddbedec124d1754d",
+    "wof:geomhash":"4644c04cc3b8aa233cafdadc114bfe59",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091900523,
-    "wof:lastmodified":1627522812,
+    "wof:lastmodified":1695886513,
     "wof:name":"Lac Iro",
     "wof:parent_id":85678527,
     "wof:placetype":"county",

--- a/data/109/190/056/1/1091900561.geojson
+++ b/data/109/190/056/1/1091900561.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.71101,
-    "geom:area_square_m":8650276795.685293,
+    "geom:area_square_m":8650275361.932552,
     "geom:bbox":"15.110689,9.654271,16.262966,10.846924",
     "geom:latitude":10.290214,
     "geom:longitude":15.735949,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.ME.MB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892141,
-    "wof:geomhash":"03fce4a232746254fc6cf8b62c55c69c",
+    "wof:geomhash":"b6795ee3254a7b9af320058f5e1d2e43",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091900561,
-    "wof:lastmodified":1627522812,
+    "wof:lastmodified":1695886513,
     "wof:name":"Mayo Boneye",
     "wof:parent_id":85678473,
     "wof:placetype":"county",

--- a/data/109/190/059/5/1091900595.geojson
+++ b/data/109/190/059/5/1091900595.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.175473,
-    "geom:area_square_m":14291658503.430111,
+    "geom:area_square_m":14291658503.430107,
     "geom:bbox":"16.0389663397,9.82917136831,17.5429663397,11.1009713683",
     "geom:latitude":10.493991,
     "geom:longitude":16.809695,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"TD.CG.LC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892143,
-    "wof:geomhash":"2a9f46158eceb12615213d763f262bd5",
+    "wof:geomhash":"ac404d1ceb08e087c8a623e6e4f1d6ad",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1091900595,
-    "wof:lastmodified":1566653735,
+    "wof:lastmodified":1695886486,
     "wof:name":"Loug Chari",
     "wof:parent_id":85678513,
     "wof:placetype":"county",

--- a/data/109/190/062/7/1091900627.geojson
+++ b/data/109/190/062/7/1091900627.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.295822,
-    "geom:area_square_m":3592303963.980631,
+    "geom:area_square_m":3592303461.03863,
     "geom:bbox":"15.025696,10.506104,16.139966,11.212097",
     "geom:latitude":10.864904,
     "geom:longitude":15.497589,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.ME.ML"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892144,
-    "wof:geomhash":"6ba997f209b3a2036991b96f0e4b2503",
+    "wof:geomhash":"784162f760c5071bfb82c28434507a61",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091900627,
-    "wof:lastmodified":1627522813,
+    "wof:lastmodified":1695886514,
     "wof:name":"Mayo Lemye",
     "wof:parent_id":85678473,
     "wof:placetype":"county",

--- a/data/109/190/064/1/1091900641.geojson
+++ b/data/109/190/064/1/1091900641.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.671754,
-    "geom:area_square_m":32445358811.999451,
+    "geom:area_square_m":32445358851.976555,
     "geom:bbox":"17.304966,9.876971,19.736966,11.679971",
     "geom:latitude":10.850746,
     "geom:longitude":18.438938,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.GR.BS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892146,
-    "wof:geomhash":"68bebb6aa8ddf647d5f83ac5153067d3",
+    "wof:geomhash":"37c2311b4ca9bc18884e89bd48fe07de",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091900641,
-    "wof:lastmodified":1627522811,
+    "wof:lastmodified":1695886512,
     "wof:name":"Bahr Signaka",
     "wof:parent_id":85678457,
     "wof:placetype":"county",

--- a/data/109/190/065/9/1091900659.geojson
+++ b/data/109/190/065/9/1091900659.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.530731,
-    "geom:area_square_m":30774450437.961662,
+    "geom:area_square_m":30774448225.081444,
     "geom:bbox":"19.698466,9.081695,22.46228,11.704771",
     "geom:latitude":10.4213,
     "geom:longitude":21.128908,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.SA.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892147,
-    "wof:geomhash":"29ac95a74245a04ce80546032945775d",
+    "wof:geomhash":"9eb3ff2cbdab66660919fc335643e2f8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091900659,
-    "wof:lastmodified":1627522812,
+    "wof:lastmodified":1695886513,
     "wof:name":"Haraze Mangueigne",
     "wof:parent_id":85678487,
     "wof:placetype":"county",

--- a/data/109/190/068/9/1091900689.geojson
+++ b/data/109/190/068/9/1091900689.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.210055,
-    "geom:area_square_m":26830488527.999374,
+    "geom:area_square_m":26830488561.317673,
     "geom:bbox":"19.612966,9.912171,21.401566,12.041971",
     "geom:latitude":10.933527,
     "geom:longitude":20.416031,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.SA.AT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892149,
-    "wof:geomhash":"e2f1d8b446a3a56badc2527a87da4069",
+    "wof:geomhash":"128240e5a66012fd30ed80865b658f98",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091900689,
-    "wof:lastmodified":1627522811,
+    "wof:lastmodified":1695886512,
     "wof:name":"Bahr Azoum",
     "wof:parent_id":85678487,
     "wof:placetype":"county",

--- a/data/109/190/070/7/1091900707.geojson
+++ b/data/109/190/070/7/1091900707.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.945627,
-    "geom:area_square_m":11456851866.633812,
+    "geom:area_square_m":11456851881.654747,
     "geom:bbox":"18.873966,11.000271,20.164766,12.122971",
     "geom:latitude":11.527572,
     "geom:longitude":19.579667,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.SA.AD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892150,
-    "wof:geomhash":"e38f10e8dba11e31c57cbd5f6a288748",
+    "wof:geomhash":"a50c1fa8927111b739a6054ffed050c2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091900707,
-    "wof:lastmodified":1627522811,
+    "wof:lastmodified":1695886512,
     "wof:name":"Aboudeia",
     "wof:parent_id":85678487,
     "wof:placetype":"county",

--- a/data/109/190/072/5/1091900725.geojson
+++ b/data/109/190/072/5/1091900725.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.375004,
-    "geom:area_square_m":4540023372.892066,
+    "geom:area_square_m":4540021623.686561,
     "geom:bbox":"15.01709,11.088977,15.505964,12.362971",
     "geom:latitude":11.734594,
     "geom:longitude":15.248363,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"TD.CG.CH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892152,
-    "wof:geomhash":"c03c00e58708e4c21e55c2393ffaa790",
+    "wof:geomhash":"8845b80a6bb7a1b3d42618599fdfd982",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1091900725,
-    "wof:lastmodified":1636501312,
+    "wof:lastmodified":1695886775,
     "wof:name":"Chari",
     "wof:parent_id":85678513,
     "wof:placetype":"county",

--- a/data/109/190/075/7/1091900757.geojson
+++ b/data/109/190/075/7/1091900757.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.268053,
-    "geom:area_square_m":27476622714.973019,
+    "geom:area_square_m":27476614428.053932,
     "geom:bbox":"15.36908,10.573971,17.362966,12.431971",
     "geom:latitude":11.546856,
     "geom:longitude":16.251898,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"TD.CG.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892154,
-    "wof:geomhash":"8b965fa61a163cc22a3368960a02ecdc",
+    "wof:geomhash":"25f25106e54ad5529e79a5bcd39f9fd4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1091900757,
-    "wof:lastmodified":1627522811,
+    "wof:lastmodified":1695886512,
     "wof:name":"Baguirmi",
     "wof:parent_id":85678513,
     "wof:placetype":"county",

--- a/data/109/190/078/5/1091900785.geojson
+++ b/data/109/190/078/5/1091900785.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.797291,
-    "geom:area_square_m":9642305959.589836,
+    "geom:area_square_m":9642305959.589872,
     "geom:bbox":"17.5419663397,11.4079713683,18.6589663397,12.6179713683",
     "geom:latitude":12.021593,
     "geom:longitude":18.109468,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"TD.GR.AB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892155,
-    "wof:geomhash":"024598966d770e169e9a71f503fbaecf",
+    "wof:geomhash":"7dbcfe22029246400489499d72b3a445",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091900785,
-    "wof:lastmodified":1566653728,
+    "wof:lastmodified":1695886485,
     "wof:name":"Abtouyour",
     "wof:parent_id":85678457,
     "wof:placetype":"county",

--- a/data/109/190/082/1/1091900821.geojson
+++ b/data/109/190/082/1/1091900821.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.697582,
-    "geom:area_square_m":8432869093.804083,
+    "geom:area_square_m":8432869105.459128,
     "geom:bbox":"18.329966,11.330971,19.180966,12.693971",
     "geom:latitude":12.134665,
     "geom:longitude":18.776886,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.GR.GR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892157,
-    "wof:geomhash":"124dd6c6c4c361d94767a66f0a573039",
+    "wof:geomhash":"a8090b5d55ea95b4fe7aa40af1118d86",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091900821,
-    "wof:lastmodified":1627522812,
+    "wof:lastmodified":1695886514,
     "wof:name":"Guera",
     "wof:parent_id":85678457,
     "wof:placetype":"county",

--- a/data/109/190/086/1/1091900861.geojson
+++ b/data/109/190/086/1/1091900861.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.749571,
-    "geom:area_square_m":21162554946.502159,
+    "geom:area_square_m":21162554946.501942,
     "geom:bbox":"21.0559663397,10.921081543,22.9750976563,12.8609713683",
     "geom:latitude":11.972318,
     "geom:longitude":22.000667,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.SI.SI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892158,
-    "wof:geomhash":"2298f659d1b064720958926560b2a03b",
+    "wof:geomhash":"4b1616fcdec1d44a6a942498f799b9bf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091900861,
-    "wof:lastmodified":1566653734,
+    "wof:lastmodified":1695886486,
     "wof:name":"Kimiti",
     "wof:parent_id":85678523,
     "wof:placetype":"county",

--- a/data/109/190/089/7/1091900897.geojson
+++ b/data/109/190/089/7/1091900897.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.513263,
-    "geom:area_square_m":6195157855.570799,
+    "geom:area_square_m":6195157855.570888,
     "geom:bbox":"14.5081176758,12.1851196289,16.1949663397,12.9951171875",
     "geom:latitude":12.540374,
     "geom:longitude":15.251931,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"TD.HD.HB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892159,
-    "wof:geomhash":"7d31f9643e3e9c8d76880f1b74d78485",
+    "wof:geomhash":"94fc964a0b5f3856d33909d6c0318d1e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091900897,
-    "wof:lastmodified":1566653733,
+    "wof:lastmodified":1695886486,
     "wof:name":"Haraze Al Biar",
     "wof:parent_id":85678435,
     "wof:placetype":"county",

--- a/data/109/190/093/9/1091900939.geojson
+++ b/data/109/190/093/9/1091900939.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.891333,
-    "geom:area_square_m":10763246237.233938,
+    "geom:area_square_m":10763246252.476076,
     "geom:bbox":"18.901966,11.599971,20.243966,13.030971",
     "geom:latitude":12.423483,
     "geom:longitude":19.564991,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.GR.MG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892161,
-    "wof:geomhash":"ec66447ae00d747206af314b95adbb4a",
+    "wof:geomhash":"dd34021680c7ee78e2cef4a388ca459e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091900939,
-    "wof:lastmodified":1627522812,
+    "wof:lastmodified":1695886514,
     "wof:name":"Mangalme",
     "wof:parent_id":85678457,
     "wof:placetype":"county",

--- a/data/109/190/098/3/1091900983.geojson
+++ b/data/109/190/098/3/1091900983.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.219242,
-    "geom:area_square_m":14725509326.252911,
+    "geom:area_square_m":14725509347.026594,
     "geom:bbox":"19.888966,11.663971,21.357966,13.058971",
     "geom:latitude":12.377893,
     "geom:longitude":20.643433,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.SI.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892163,
-    "wof:geomhash":"0bc97fae4642fddadb55f81860d154fa",
+    "wof:geomhash":"a62ad2b9f37dfb686d6bf98d8014f449",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091900983,
-    "wof:lastmodified":1627522811,
+    "wof:lastmodified":1695886512,
     "wof:name":"Djourf Al Ahmar",
     "wof:parent_id":85678523,
     "wof:placetype":"county",

--- a/data/109/190/100/7/1091901007.geojson
+++ b/data/109/190/100/7/1091901007.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.329267,
-    "geom:area_square_m":16054558735.068459,
+    "geom:area_square_m":16054558735.06839,
     "geom:bbox":"16.0899663397,11.4719713683,17.6799663397,13.1569713683",
     "geom:latitude":12.371165,
     "geom:longitude":16.879734,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"TD.HD.DB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892164,
-    "wof:geomhash":"989af1d7bc17691c72531977475f6242",
+    "wof:geomhash":"e6eb7c045a088bc7c615ab1e42775ca7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1091901007,
-    "wof:lastmodified":1566653732,
+    "wof:lastmodified":1695886486,
     "wof:name":"Dababa",
     "wof:parent_id":85678435,
     "wof:placetype":"county",

--- a/data/109/190/103/5/1091901035.geojson
+++ b/data/109/190/103/5/1091901035.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.318706,
-    "geom:area_square_m":3841226949.399618,
+    "geom:area_square_m":3841226955.059978,
     "geom:bbox":"20.762966,12.634971,21.680966,13.208971",
     "geom:latitude":12.91047,
     "geom:longitude":21.24028,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.OA.AB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892166,
-    "wof:geomhash":"76d48b297c13f3bae8f53ae580990691",
+    "wof:geomhash":"82b0a75b3712a6c560e953ec34452c17",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091901035,
-    "wof:lastmodified":1627522810,
+    "wof:lastmodified":1695886511,
     "wof:name":"Abdi",
     "wof:parent_id":85678463,
     "wof:placetype":"county",

--- a/data/109/190/107/1/1091901071.geojson
+++ b/data/109/190/107/1/1091901071.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.700808,
-    "geom:area_square_m":8446789175.096802,
+    "geom:area_square_m":8446789175.096786,
     "geom:bbox":"14.8349663397,12.5501098633,16.1949663397,13.3929713683",
     "geom:latitude":12.902259,
     "geom:longitude":15.539618,
@@ -87,9 +87,10 @@
     "wof:concordances":{
         "hasc:id":"TD.HD.DG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892167,
-    "wof:geomhash":"a2fcac85c6bf46b560a292cea075d08d",
+    "wof:geomhash":"bd04e801801592173f477d089fdf2886",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1091901071,
-    "wof:lastmodified":1566653732,
+    "wof:lastmodified":1695886486,
     "wof:name":"Dagana",
     "wof:parent_id":85678435,
     "wof:placetype":"county",

--- a/data/109/190/110/1/1091901101.geojson
+++ b/data/109/190/110/1/1091901101.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.974088,
-    "geom:area_square_m":11740807256.857235,
+    "geom:area_square_m":11740807274.136604,
     "geom:bbox":"16.957966,12.124971,18.048966,13.496971",
     "geom:latitude":12.896018,
     "geom:longitude":17.572369,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.BA.FI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892169,
-    "wof:geomhash":"23f57194e58aac7460339a9755b42eef",
+    "wof:geomhash":"a1672140cc518d0d28e002d1a06bb175",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091901101,
-    "wof:lastmodified":1627522811,
+    "wof:lastmodified":1695886512,
     "wof:name":"Fittri",
     "wof:parent_id":85678449,
     "wof:placetype":"county",

--- a/data/109/190/112/9/1091901129.geojson
+++ b/data/109/190/112/9/1091901129.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.281735,
-    "geom:area_square_m":3387898933.189211,
+    "geom:area_square_m":3387898933.189208,
     "geom:bbox":"14.7929663397,13.0949713683,15.5759663397,13.7419713683",
     "geom:latitude":13.467699,
     "geom:longitude":15.179177,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"TD.LC.WA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892170,
-    "wof:geomhash":"b276c60976e1c1269fe2f1b013a9d73f",
+    "wof:geomhash":"abaf926c70d0e6cb680e0b21f47aec1f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091901129,
-    "wof:lastmodified":1566653736,
+    "wof:lastmodified":1695886486,
     "wof:name":"Wayi",
     "wof:parent_id":85678445,
     "wof:placetype":"county",

--- a/data/109/190/116/5/1091901165.geojson
+++ b/data/109/190/116/5/1091901165.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.240651,
-    "geom:area_square_m":2893574907.780674,
+    "geom:area_square_m":2893574907.780676,
     "geom:bbox":"15.3929663397,13.1539713683,15.9348754883,13.8779713683",
     "geom:latitude":13.492672,
     "geom:longitude":15.70111,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.KM.WB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892172,
-    "wof:geomhash":"53df7fecdb10ed0181e0506d69780c3f",
+    "wof:geomhash":"62b4ed499068d0e40dc07d9ce74b6161",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091901165,
-    "wof:lastmodified":1566653731,
+    "wof:lastmodified":1695886485,
     "wof:name":"Wadi Bissam",
     "wof:parent_id":85678439,
     "wof:placetype":"county",

--- a/data/109/190/120/5/1091901205.geojson
+++ b/data/109/190/120/5/1091901205.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.692865,
-    "geom:area_square_m":8328516333.232713,
+    "geom:area_square_m":8328516346.142994,
     "geom:bbox":"21.252966,12.803971,22.293966,14.125971",
     "geom:latitude":13.55862,
     "geom:longitude":21.818942,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.OA.AS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892173,
-    "wof:geomhash":"930fc552277108a797b3dee26ab165f3",
+    "wof:geomhash":"d9eaa40df67ea714e7c25de97a44cc67",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091901205,
-    "wof:lastmodified":1627522811,
+    "wof:lastmodified":1695886512,
     "wof:name":"Assoungha",
     "wof:parent_id":85678463,
     "wof:placetype":"county",

--- a/data/109/190/124/7/1091901247.geojson
+++ b/data/109/190/124/7/1091901247.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.829685,
-    "geom:area_square_m":9969427454.57613,
+    "geom:area_square_m":9969420524.871777,
     "geom:bbox":"15.602112,13.069971,17.270966,14.314971",
     "geom:latitude":13.648192,
     "geom:longitude":16.535202,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.BG.BU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892174,
-    "wof:geomhash":"73d49c5287be3c0a63682ce684a090ad",
+    "wof:geomhash":"fdfbe023cc01badb8a0dc57feb518062",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091901247,
-    "wof:lastmodified":1627522811,
+    "wof:lastmodified":1695886512,
     "wof:name":"Barh-El-Gazel Sud",
     "wof:parent_id":85678519,
     "wof:placetype":"county",

--- a/data/109/190/126/5/1091901265.geojson
+++ b/data/109/190/126/5/1091901265.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.380712,
-    "geom:area_square_m":16586251146.872618,
+    "geom:area_square_m":16586241807.575186,
     "geom:bbox":"13.473877,12.992971,15.041966,14.526917",
     "geom:latitude":13.704949,
     "geom:longitude":14.207418,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"TD.LC.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892176,
-    "wof:geomhash":"ac9194e39772b136eba634c4998bc23e",
+    "wof:geomhash":"febc17974cb57efa081dc1b7c7cf2996",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091901265,
-    "wof:lastmodified":1627522812,
+    "wof:lastmodified":1695886514,
     "wof:name":"Mamdi",
     "wof:parent_id":85678445,
     "wof:placetype":"county",

--- a/data/109/190/130/5/1091901305.geojson
+++ b/data/109/190/130/5/1091901305.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.827171,
-    "geom:area_square_m":9918512667.679438,
+    "geom:area_square_m":9918512683.732344,
     "geom:bbox":"14.553966,13.634971,16.142966,14.610971",
     "geom:latitude":14.132719,
     "geom:longitude":15.259996,
@@ -90,9 +90,10 @@
     "wof:concordances":{
         "hasc:id":"TD.KM.KM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892177,
-    "wof:geomhash":"84621c0c93746be64a64e96729f518b3",
+    "wof:geomhash":"4776d9a3aebd7cc7dcc296b4f1b4af46",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1091901305,
-    "wof:lastmodified":1636501312,
+    "wof:lastmodified":1695886775,
     "wof:name":"Kanem",
     "wof:parent_id":85678439,
     "wof:placetype":"county",

--- a/data/109/190/134/9/1091901349.geojson
+++ b/data/109/190/134/9/1091901349.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.797547,
-    "geom:area_square_m":9550579386.307537,
+    "geom:area_square_m":9550579402.105782,
     "geom:bbox":"21.432966,13.917971,22.566966,14.981971",
     "geom:latitude":14.430562,
     "geom:longitude":21.953406,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.BI.DT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892179,
-    "wof:geomhash":"5eb20e17e1fec7d0841e919be0590e82",
+    "wof:geomhash":"af5712fd0059ee285966794843deea74",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091901349,
-    "wof:lastmodified":1627522811,
+    "wof:lastmodified":1695886512,
     "wof:name":"Dar Tama",
     "wof:parent_id":85678453,
     "wof:placetype":"county",

--- a/data/109/190/137/1/1091901371.geojson
+++ b/data/109/190/137/1/1091901371.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.407765,
-    "geom:area_square_m":28908680957.023727,
+    "geom:area_square_m":28908680957.023216,
     "geom:bbox":"18.7059663397,12.6869713683,20.3689663397,15.6613713683",
     "geom:latitude":13.82098,
     "geom:longitude":19.606661,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"TD.BA.BE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892180,
-    "wof:geomhash":"c27242c4b2c56c23e62517327c939f2d",
+    "wof:geomhash":"b0b39b317b8c79409a3e48096534b181",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1091901371,
-    "wof:lastmodified":1566653733,
+    "wof:lastmodified":1695886486,
     "wof:name":"Batha Est",
     "wof:parent_id":85678449,
     "wof:placetype":"county",

--- a/data/109/190/140/9/1091901409.geojson
+++ b/data/109/190/140/9/1091901409.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.980491,
-    "geom:area_square_m":23654923489.220573,
+    "geom:area_square_m":23654923529.939724,
     "geom:bbox":"20.041466,14.038971,21.686466,15.898671",
     "geom:latitude":14.99129,
     "geom:longitude":20.786677,
@@ -93,9 +93,10 @@
     "wof:concordances":{
         "hasc:id":"TD.BI.BL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892182,
-    "wof:geomhash":"5be039c229a8fea22deac5b77ba72718",
+    "wof:geomhash":"9ebad77348a2d93651cadbb25ec38376",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1091901409,
-    "wof:lastmodified":1636501312,
+    "wof:lastmodified":1695886775,
     "wof:name":"Biltine",
     "wof:parent_id":85678453,
     "wof:placetype":"county",

--- a/data/109/190/145/3/1091901453.geojson
+++ b/data/109/190/145/3/1091901453.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.920377,
-    "geom:area_square_m":10977083887.77557,
+    "geom:area_square_m":10977083887.77544,
     "geom:bbox":"21.9319991999,14.5889713683,23.0007663397,15.9831713683",
     "geom:latitude":15.300531,
     "geom:longitude":22.428815,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"TD.BI.IB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892183,
-    "wof:geomhash":"07d9c678060895e6f0b23992a19f4cc7",
+    "wof:geomhash":"3ca322ebae6c135a5d3183b8ac35f63f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1091901453,
-    "wof:lastmodified":1566653731,
+    "wof:lastmodified":1695886485,
     "wof:name":"Iriba",
     "wof:parent_id":85678453,
     "wof:placetype":"county",

--- a/data/109/190/148/5/1091901485.geojson
+++ b/data/109/190/148/5/1091901485.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.182386,
-    "geom:area_square_m":50104636371.919846,
+    "geom:area_square_m":50104636371.920059,
     "geom:bbox":"17.2339663397,12.4519713683,20.0439663397,16.1083713683",
     "geom:latitude":14.314343,
     "geom:longitude":18.625023,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"TD.BA.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892185,
-    "wof:geomhash":"8b1f3b32b67960f8a7e1def2b0648022",
+    "wof:geomhash":"d4f0505460575153a53a44a4262fc81c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1091901485,
-    "wof:lastmodified":1566653737,
+    "wof:lastmodified":1695886486,
     "wof:name":"Batha Ouest",
     "wof:parent_id":85678449,
     "wof:placetype":"county",

--- a/data/109/190/152/5/1091901525.geojson
+++ b/data/109/190/152/5/1091901525.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.491482,
-    "geom:area_square_m":41719313003.906136,
+    "geom:area_square_m":41719308305.959229,
     "geom:bbox":"15.961966,13.661971,18.050966,16.243103",
     "geom:latitude":14.896774,
     "geom:longitude":17.034941,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.BG.BN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892187,
-    "wof:geomhash":"11788ad6a5e2a03b609deab233785705",
+    "wof:geomhash":"f5d792c82fdb7f7165ba7fcd69cd1c8e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091901525,
-    "wof:lastmodified":1627522811,
+    "wof:lastmodified":1695886512,
     "wof:name":"Barh-El-Gazel Nord",
     "wof:parent_id":85678519,
     "wof:placetype":"county",

--- a/data/109/190/157/1/1091901571.geojson
+++ b/data/109/190/157/1/1091901571.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.548187,
-    "geom:area_square_m":54220316479.391701,
+    "geom:area_square_m":54220316479.391953,
     "geom:bbox":"13.611328125,13.9959713683,16.6939086914,16.8245239258",
     "geom:latitude":15.386319,
     "geom:longitude":15.249227,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.KM.NK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892189,
-    "wof:geomhash":"82690ab1e9c27adcab4031c3feb66af1",
+    "wof:geomhash":"ae91560cd44697a4242cee7acd5950cf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091901571,
-    "wof:lastmodified":1566653726,
+    "wof:lastmodified":1695886485,
     "wof:name":"Nord Kanem",
     "wof:parent_id":85678439,
     "wof:placetype":"county",

--- a/data/109/190/160/7/1091901607.geojson
+++ b/data/109/190/160/7/1091901607.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.146337,
-    "geom:area_square_m":72793247194.795334,
+    "geom:area_square_m":72793251434.750473,
     "geom:bbox":"17.027466,15.313971,20.744866,18.024271",
     "geom:latitude":16.639063,
     "geom:longitude":19.140487,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"TD.BR.BK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892190,
-    "wof:geomhash":"126a8c127996e65f0871f30d24492d9a",
+    "wof:geomhash":"34fad5af48f0f49982497d1b8451a978",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1091901607,
-    "wof:lastmodified":1636501312,
+    "wof:lastmodified":1695886775,
     "wof:name":"Borkou",
     "wof:parent_id":85678501,
     "wof:placetype":"county",

--- a/data/109/190/164/9/1091901649.geojson
+++ b/data/109/190/164/9/1091901649.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":11.22746,
-    "geom:area_square_m":129888355687.482147,
+    "geom:area_square_m":129888355687.482117,
     "geom:bbox":"16.4976806641,18.6482708687,21.0283663397,23.0753713683",
     "geom:latitude":20.65418,
     "geom:longitude":18.49652,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"TD.TI.TE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892192,
-    "wof:geomhash":"2f43855f097d1431f6e57a7af7fb1027",
+    "wof:geomhash":"8d3a58aff9b983a383c3d1ea690fa53f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091901649,
-    "wof:lastmodified":1566653733,
+    "wof:lastmodified":1695886486,
     "wof:name":"Tibesti Est",
     "wof:parent_id":85678501,
     "wof:placetype":"county",

--- a/data/109/190/165/9/1091901659.geojson
+++ b/data/109/190/165/9/1091901659.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":7.509708,
-    "geom:area_square_m":86673353286.815781,
+    "geom:area_square_m":86673353286.816193,
     "geom:bbox":"14.9794663397,17.0844726563,17.4331054688,23.4935713683",
     "geom:latitude":20.980395,
     "geom:longitude":16.157074,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"TD.TI.TO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892193,
-    "wof:geomhash":"0cd551cef6149e84217b3137f50fd899",
+    "wof:geomhash":"4abc850172b6323a5b9a3a0a949adf79",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091901659,
-    "wof:lastmodified":1566653732,
+    "wof:lastmodified":1695886486,
     "wof:name":"Tibesti Ouest",
     "wof:parent_id":85678505,
     "wof:placetype":"county",

--- a/data/109/190/169/1/1091901691.geojson
+++ b/data/109/190/169/1/1091901691.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.107128,
-    "geom:area_square_m":1307391307.994287,
+    "geom:area_square_m":1307390794.165856,
     "geom:bbox":"15.893566,9.048471,16.369366,9.518371",
     "geom:latitude":9.261578,
     "geom:longitude":16.143623,
@@ -61,9 +61,10 @@
     "wof:concordances":{
         "hasc:id":"TD.TA.TC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892195,
-    "wof:geomhash":"4d8032d1d47f9de9b6f134407fc4d0d8",
+    "wof:geomhash":"e6e09c7d691ff45d109a60691a260314",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -73,7 +74,7 @@
         }
     ],
     "wof:id":1091901691,
-    "wof:lastmodified":1627522813,
+    "wof:lastmodified":1695886514,
     "wof:name":"Tandjile Centre",
     "wof:parent_id":85678477,
     "wof:placetype":"county",

--- a/data/109/190/173/3/1091901733.geojson
+++ b/data/109/190/173/3/1091901733.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.396225,
-    "geom:area_square_m":4766585579.397963,
+    "geom:area_square_m":4766589213.656622,
     "geom:bbox":"15.876099,13.022971,16.617316,13.746887",
     "geom:latitude":13.368811,
     "geom:longitude":16.218162,
@@ -61,9 +61,10 @@
     "wof:concordances":{
         "hasc:id":"TD.BG.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892197,
-    "wof:geomhash":"fff88aecdf4c81b446409658d433001c",
+    "wof:geomhash":"9d1158af50bcaee7973bf7cd878c2268",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -73,7 +74,7 @@
         }
     ],
     "wof:id":1091901733,
-    "wof:lastmodified":1627522811,
+    "wof:lastmodified":1695886512,
     "wof:name":"Barh-El-Gazel Ouest",
     "wof:parent_id":85678519,
     "wof:placetype":"county",

--- a/data/109/190/177/5/1091901775.geojson
+++ b/data/109/190/177/5/1091901775.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.639855,
-    "geom:area_square_m":7632635046.127778,
+    "geom:area_square_m":7632637762.106511,
     "geom:bbox":"21.004966,14.717971,22.115,15.942771",
     "geom:latitude":15.265825,
     "geom:longitude":21.6554,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"TD.BI.MG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892199,
-    "wof:geomhash":"726a286bb021c87cdfa93af4bb248372",
+    "wof:geomhash":"a60ad06144abdc67df725155c19d8df9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1091901775,
-    "wof:lastmodified":1627522813,
+    "wof:lastmodified":1695886514,
     "wof:name":"Megri",
     "wof:parent_id":85678453,
     "wof:placetype":"county",

--- a/data/109/190/180/9/1091901809.geojson
+++ b/data/109/190/180/9/1091901809.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.908977,
-    "geom:area_square_m":10803353613.429806,
+    "geom:area_square_m":10803359152.478081,
     "geom:bbox":"22.015066,15.493271,24.004266,16.564471",
     "geom:latitude":15.991027,
     "geom:longitude":23.086111,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.EE.WH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892200,
-    "wof:geomhash":"70f6b9069170c06a00cfb58ef21a04e9",
+    "wof:geomhash":"4bfcb6c24bc50fba02e5cb56390cc84f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091901809,
-    "wof:lastmodified":1627522813,
+    "wof:lastmodified":1695886514,
     "wof:name":"Wadi Hawar",
     "wof:parent_id":1108808535,
     "wof:placetype":"county",

--- a/data/109/190/183/7/1091901837.geojson
+++ b/data/109/190/183/7/1091901837.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.294416,
-    "geom:area_square_m":73982401313.274734,
+    "geom:area_square_m":73982382051.050079,
     "geom:bbox":"22.267866,15.989211,24.004266,20.396277",
     "geom:latitude":18.065931,
     "geom:longitude":23.13164,
@@ -61,9 +61,10 @@
     "wof:concordances":{
         "hasc:id":"TD.EE.AD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892202,
-    "wof:geomhash":"bb1ea51368033488d35b51b595b3b65f",
+    "wof:geomhash":"6d24c0ca1bbf063101b20b41c7b8d874",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -73,7 +74,7 @@
         }
     ],
     "wof:id":1091901837,
-    "wof:lastmodified":1627522811,
+    "wof:lastmodified":1695886513,
     "wof:name":"Am-Djarass",
     "wof:parent_id":1108808537,
     "wof:placetype":"county",

--- a/data/109/190/187/1/1091901871.geojson
+++ b/data/109/190/187/1/1091901871.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.692587,
-    "geom:area_square_m":20078953618.575508,
+    "geom:area_square_m":20078958312.867123,
     "geom:bbox":"20.400566,15.571971,22.328066,16.994294",
     "geom:latitude":16.377061,
     "geom:longitude":21.251327,
@@ -61,9 +61,10 @@
     "wof:concordances":{
         "hasc:id":"TD.EO.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892204,
-    "wof:geomhash":"7eb2a25a3d4aab3ae82560a9e0be949a",
+    "wof:geomhash":"ef0097fcac9c7c983386315d2fb4cbe7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -73,7 +74,7 @@
         }
     ],
     "wof:id":1091901871,
-    "wof:lastmodified":1627522813,
+    "wof:lastmodified":1695886515,
     "wof:name":"Mourtcha",
     "wof:parent_id":1108808537,
     "wof:placetype":"county",

--- a/data/109/190/187/3/1091901873.geojson
+++ b/data/109/190/187/3/1091901873.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":9.034933,
-    "geom:area_square_m":105720918339.206879,
+    "geom:area_square_m":105720923261.310928,
     "geom:bbox":"19.191203,16.665471,22.350166,21.074571",
     "geom:latitude":18.827184,
     "geom:longitude":21.12236,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.EO.FA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892206,
-    "wof:geomhash":"7c18040e5999a703cae6eb67dadbb39f",
+    "wof:geomhash":"c9e8c001a33c16724e4b6521ceff40ad",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091901873,
-    "wof:lastmodified":1627522811,
+    "wof:lastmodified":1695886513,
     "wof:name":"Ennedi Ouest",
     "wof:parent_id":1108808537,
     "wof:placetype":"county",

--- a/data/109/190/188/7/1091901887.geojson
+++ b/data/109/190/188/7/1091901887.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.728635,
-    "geom:area_square_m":79283972486.385971,
+    "geom:area_square_m":79283972486.385834,
     "geom:bbox":"15.4166870117,16.0982713683,19.8024701764,18.827349784",
     "geom:latitude":17.682347,
     "geom:longitude":17.33406,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TD.BR.BY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892207,
-    "wof:geomhash":"77296d1463187eb5a17ba1be4ecd6060",
+    "wof:geomhash":"62c538e0f2dd022cdd4f60bad872fe2e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091901887,
-    "wof:lastmodified":1566653731,
+    "wof:lastmodified":1695886485,
     "wof:name":"Borkou Yala",
     "wof:parent_id":85678501,
     "wof:placetype":"county",

--- a/data/109/190/192/7/1091901927.geojson
+++ b/data/109/190/192/7/1091901927.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.11818,
-    "geom:area_square_m":1439699627.391146,
+    "geom:area_square_m":1439699028.387225,
     "geom:bbox":"14.147261,9.697953,14.741566,9.998474",
     "geom:latitude":9.868838,
     "geom:longitude":14.46531,
@@ -61,9 +61,10 @@
     "wof:concordances":{
         "hasc:id":"TD.MW.MB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1473892209,
-    "wof:geomhash":"195c88ff6f9f4d73aa800e869ca2b0f4",
+    "wof:geomhash":"ddb19a2f375f9012c883da4223b316d9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -73,7 +74,7 @@
         }
     ],
     "wof:id":1091901927,
-    "wof:lastmodified":1627522813,
+    "wof:lastmodified":1695886515,
     "wof:name":"Mayo-Binder",
     "wof:parent_id":85678495,
     "wof:placetype":"county",

--- a/data/110/880/853/5/1108808535.geojson
+++ b/data/110/880/853/5/1108808535.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.942287,
-    "geom:area_square_m":23058427008.440987,
+    "geom:area_square_m":23058427379.470093,
     "geom:bbox":"22.015066,15.493271,24.004266,16.786871",
     "geom:latitude":16.234937,
     "geom:longitude":23.089181,
@@ -126,11 +126,13 @@
         "gn:id":7603256,
         "gp:id":-2344947,
         "hasc:id":"TD.EE",
+        "iso:code":"TD-EE",
         "iso:id":"TD-EE"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TD",
     "wof:created":1486415130,
-    "wof:geomhash":"b85d5469616d922a8133e353e6d83933",
+    "wof:geomhash":"33807834a525124ada8f89a1802ae9eb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -147,7 +149,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1614893135,
+    "wof:lastmodified":1695884486,
     "wof:name":"Ennedi Est",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/110/880/853/7/1108808537.geojson
+++ b/data/110/880/853/7/1108808537.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":14.500009,
-    "geom:area_square_m":170125638692.915192,
+    "geom:area_square_m":170125637327.804932,
     "geom:bbox":"20.054524,15.571971,24.004266,21.074571",
     "geom:latitude":18.359652,
     "geom:longitude":21.99595,
@@ -111,12 +111,14 @@
     "wof:concordances":{
         "fips:code":"CD28",
         "hasc:id":"TD.EO",
+        "iso:code":"TD-EO",
         "iso:id":"TD-EO",
         "wd:id":"Q16632172"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TD",
     "wof:created":1486415132,
-    "wof:geomhash":"9b12473fc0b23995dfbf2088d67f8acd",
+    "wof:geomhash":"4024c6a75b2e8d5109d937fb9dfc08a4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -133,7 +135,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1690868568,
+    "wof:lastmodified":1695884328,
     "wof:name":"Ennedi Ouest",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/421/179/001/421179001.geojson
+++ b/data/421/179/001/421179001.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.479281,
-    "geom:area_square_m":17773321104.605125,
+    "geom:area_square_m":17773321132.387669,
     "geom:bbox":"20.055966,13.008971,21.680966,14.413971",
     "geom:latitude":13.667332,
     "geom:longitude":20.833407,
@@ -122,12 +122,13 @@
         "qs_pg:id":145329,
         "wd:id":"Q1974522"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TD",
     "wof:created":1459009201,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"34ca4c4d49992a46b83bf25d19825c77",
+    "wof:geomhash":"ba933748a0282e51424bf0c16d25878e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":421179001,
-    "wof:lastmodified":1690868571,
+    "wof:lastmodified":1695886514,
     "wof:name":"Ouara",
     "wof:parent_id":85678463,
     "wof:placetype":"county",

--- a/data/421/193/929/421193929.geojson
+++ b/data/421/193/929/421193929.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029071,
-    "geom:area_square_m":351467497.471107,
+    "geom:area_square_m":351467497.471111,
     "geom:bbox":"14.890076,11.983093,15.160095,12.224954",
     "geom:latitude":12.114988,
     "geom:longitude":15.037736,
@@ -438,6 +438,7 @@
         "hasc:id":"TD.NJ.NU",
         "qs_pg:id":525930
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         85678491,
         890440301
@@ -447,7 +448,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"eeeeb4e8078d68c730b3d2a47abadb6d",
+    "wof:geomhash":"17f660efcbc5303274f067fb6a0af0ad",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -457,7 +458,7 @@
         }
     ],
     "wof:id":421193929,
-    "wof:lastmodified":1607981929,
+    "wof:lastmodified":1695886403,
     "wof:name":"N'Djamena",
     "wof:parent_id":85678491,
     "wof:placetype":"county",

--- a/data/856/323/25/85632325.geojson
+++ b/data/856/323/25/85632325.geojson
@@ -1183,6 +1183,7 @@
         "hasc:id":"TD",
         "icao:code":"TT",
         "ioc:id":"CHA",
+        "iso:code":"TD",
         "itu:id":"TCD",
         "loc:id":"n80049721",
         "m49:code":"148",
@@ -1197,6 +1198,7 @@
         "wk:page":"Chad",
         "wmo:id":"CD"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TD",
     "wof:country_alpha3":"TCD",
     "wof:geom_alt":[
@@ -1220,7 +1222,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1694639532,
+    "wof:lastmodified":1695881188,
     "wof:name":"Chad",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/784/35/85678435.geojson
+++ b/data/856/784/35/85678435.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.543336,
-    "geom:area_square_m":30696505765.736012,
+    "geom:area_square_m":30696500338.637058,
     "geom:bbox":"14.508118,11.471971,17.679966,13.392971",
     "geom:latitude":12.551653,
     "geom:longitude":16.181968,
@@ -226,15 +226,17 @@
         "fips:code":"CD18",
         "gp:id":2344948,
         "hasc:id":"TD.HD",
+        "iso:code":"TD-HL",
         "iso:id":"TD-HL",
         "unlc:id":"TD-HL",
         "wd:id":"Q1042437"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"04c335f4a839f863be8aea086fe85c91",
+    "wof:geomhash":"e4c7dba54398aecacc5605dbafdf0b49",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -251,7 +253,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1690868563,
+    "wof:lastmodified":1695884881,
     "wof:name":"Hadjer-Lamis",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/784/39/85678439.geojson
+++ b/data/856/784/39/85678439.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.616011,
-    "geom:area_square_m":67032404054.851952,
+    "geom:area_square_m":67032417964.740547,
     "geom:bbox":"13.611328,13.153971,16.693909,16.824524",
     "geom:latitude":15.120534,
     "geom:longitude":15.270177,
@@ -292,16 +292,18 @@
         "gn:id":2430873,
         "gp:id":2344950,
         "hasc:id":"TD.KM",
+        "iso:code":"TD-KA",
         "iso:id":"TD-KA",
         "qs_pg:id":257793,
         "wd:id":"Q849841",
         "wk:page":"Kanem Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"979e6d189f439355351117ca403af085",
+    "wof:geomhash":"91c7b0635d65afb40a89194136a273a7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -318,7 +320,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1690868565,
+    "wof:lastmodified":1695884882,
     "wof:name":"Kanem",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/784/45/85678445.geojson
+++ b/data/856/784/45/85678445.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.662447,
-    "geom:area_square_m":19974150080.06179,
+    "geom:area_square_m":19974140745.97995,
     "geom:bbox":"13.473877,12.992971,15.575966,14.526917",
     "geom:latitude":13.664742,
     "geom:longitude":14.372102,
@@ -294,17 +294,19 @@
         "gn:id":2429323,
         "gp:id":2344951,
         "hasc:id":"TD.LC",
+        "iso:code":"TD-LC",
         "iso:id":"TD-LC",
         "qs_pg:id":946771,
         "unlc:id":"TD-LC",
         "wd:id":"Q867869",
         "wk:page":"Lac Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"af6491140b6abaa0ba388ea438d51c65",
+    "wof:geomhash":"81f66bed8b0678b3e65bae02ac24fc85",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -321,7 +323,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1690868564,
+    "wof:lastmodified":1695884882,
     "wof:name":"Lac",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/784/49/85678449.geojson
+++ b/data/856/784/49/85678449.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":7.564239,
-    "geom:area_square_m":90754124585.801086,
+    "geom:area_square_m":90754124730.984772,
     "geom:bbox":"16.957966,12.124971,20.368966,16.108371",
     "geom:latitude":13.974656,
     "geom:longitude":18.801931,
@@ -294,17 +294,19 @@
         "gn:id":2435899,
         "gp:id":2344945,
         "hasc:id":"TD.BA",
+        "iso:code":"TD-BA",
         "iso:id":"TD-BA",
         "qs_pg:id":257792,
         "unlc:id":"TD-BA",
         "wd:id":"Q180414",
         "wk:page":"Batha Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b81735c9d9dd8d33ecc5f99e79f7992a",
+    "wof:geomhash":"6f2b35c12738f554cd0b0e4c2ddcc2d0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -321,7 +323,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1690868566,
+    "wof:lastmodified":1695884882,
     "wof:name":"Batha",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/784/53/85678453.geojson
+++ b/data/856/784/53/85678453.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.33794,
-    "geom:area_square_m":51811306232.516785,
+    "geom:area_square_m":51811306346.69416,
     "geom:bbox":"20.041466,13.917971,23.000766,15.983171",
     "geom:latitude":14.99423,
     "geom:longitude":21.477642,
@@ -292,17 +292,19 @@
         "gn:id":244877,
         "gp:id":2344946,
         "hasc:id":"TD.BI",
+        "iso:code":"TD-WF",
         "iso:id":"TD-WF",
         "qs_pg:id":984069,
         "unlc:id":"TD-WF",
         "wd:id":"Q860813",
         "wk:page":"Wadi Fira Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"85881bd5a89ea00a4edc5893b8abf781",
+    "wof:geomhash":"5f768834a093ab93fef98d53c53e1ed6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -319,7 +321,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1690868564,
+    "wof:lastmodified":1695884882,
     "wof:name":"Wadi Fira",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/784/57/85678457.geojson
+++ b/data/856/784/57/85678457.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.05796,
-    "geom:area_square_m":61283780102.627235,
+    "geom:area_square_m":61283780182.702675,
     "geom:bbox":"17.304966,9.876971,20.243966,13.030971",
     "geom:latitude":11.489537,
     "geom:longitude":18.63205,
@@ -293,17 +293,19 @@
         "gn:id":2431555,
         "gp:id":2344949,
         "hasc:id":"TD.GR",
+        "iso:code":"TD-GR",
         "iso:id":"TD-GR",
         "qs_pg:id":959516,
         "unlc:id":"TD-GR",
         "wd:id":"Q175706",
         "wk:page":"Gu\u00e9ra Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1e32699d8a8055aa29027987ed27d4dd",
+    "wof:geomhash":"88419fc1d89019f44ae1726b041a93d4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -320,7 +322,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1690868562,
+    "wof:lastmodified":1695884486,
     "wof:name":"Gu\u00e9ra",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/784/63/85678463.geojson
+++ b/data/856/784/63/85678463.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.490852,
-    "geom:area_square_m":29943064387.237457,
+    "geom:area_square_m":29943064433.590694,
     "geom:bbox":"20.055966,12.634971,22.293966,14.413971",
     "geom:latitude":13.540251,
     "geom:longitude":21.159607,
@@ -299,16 +299,18 @@
         "gn:id":242246,
         "gp:id":2344956,
         "hasc:id":"TD.OA",
+        "iso:code":"TD-OD",
         "iso:id":"TD-OD",
         "qs_pg:id":219523,
         "wd:id":"Q841338",
         "wk:page":"Ouadda\u00ef Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d010df12ca3bb68ef9e03a2251196f33",
+    "wof:geomhash":"ca6e6bf83a740c4286b98e4a75464a66",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -325,7 +327,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1690868565,
+    "wof:lastmodified":1695884486,
     "wof:name":"Ouadda\u00ef",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/784/67/85678467.geojson
+++ b/data/856/784/67/85678467.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.73111,
-    "geom:area_square_m":8934923839.023966,
+    "geom:area_square_m":8934923847.869125,
     "geom:bbox":"15.287466,8.239371,16.636966,9.244271",
     "geom:latitude":8.754713,
     "geom:longitude":15.904336,
@@ -304,17 +304,19 @@
         "gn:id":2429060,
         "gp:id":2344952,
         "hasc:id":"TD.LO",
+        "iso:code":"TD-LO",
         "iso:id":"TD-LO",
         "qs_pg:id":887937,
         "unlc:id":"TD-LO",
         "wd:id":"Q305257",
         "wk:page":"Logone Occidental Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f3c40e5cc45b48c99328e28648eb9157",
+    "wof:geomhash":"95abf305974d2005899c37bbbe53c954",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -331,7 +333,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1690868563,
+    "wof:lastmodified":1695884882,
     "wof:name":"Logone Occidental",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/784/69/85678469.geojson
+++ b/data/856/784/69/85678469.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.880777,
-    "geom:area_square_m":23018203290.528408,
+    "geom:area_square_m":23018191694.916714,
     "geom:bbox":"15.242123,7.457886,17.291566,9.138571",
     "geom:latitude":8.195028,
     "geom:longitude":16.407443,
@@ -288,17 +288,19 @@
         "gn:id":2429058,
         "gp:id":2344953,
         "hasc:id":"TD.LR",
+        "iso:code":"TD-LR",
         "iso:id":"TD-LR",
         "qs_pg:id":91440,
         "unlc:id":"TD-LR",
         "wd:id":"Q167514",
         "wk:page":"Logone Oriental Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2661d5781bcf72d354669e779425ba1e",
+    "wof:geomhash":"7975917766e0187c81fc581acf0587a5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -315,7 +317,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1690868563,
+    "wof:lastmodified":1695884882,
     "wof:name":"Logone Oriental",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/784/73/85678473.geojson
+++ b/data/856/784/73/85678473.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.504775,
-    "geom:area_square_m":18312023394.367916,
+    "geom:area_square_m":18312023355.621246,
     "geom:bbox":"14.721166,9.207471,16.262966,11.212097",
     "geom:latitude":10.201674,
     "geom:longitude":15.544168,
@@ -291,17 +291,19 @@
         "gn:id":2428132,
         "gp:id":56013483,
         "hasc:id":"TD.ME",
+        "iso:code":"TD-ME",
         "iso:id":"TD-ME",
         "qs_pg:id":33451,
         "unlc:id":"TD-ME",
         "wd:id":"Q911421",
         "wk:page":"Mayo-Kebbi Est Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e8894ce0b444bedfe439d15271b8cdf3",
+    "wof:geomhash":"194cd209fe896390d63fd2d8908ecc07",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -318,7 +320,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1690868564,
+    "wof:lastmodified":1695884486,
     "wof:name":"Mayo Kebbi Est",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/784/77/85678477.geojson
+++ b/data/856/784/77/85678477.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.45704,
-    "geom:area_square_m":17767403966.695732,
+    "geom:area_square_m":17767403985.882935,
     "geom:bbox":"15.420966,9.010771,17.587966,10.264971",
     "geom:latitude":9.536077,
     "geom:longitude":16.476823,
@@ -287,17 +287,19 @@
         "gn:id":2425287,
         "gp:id":2344958,
         "hasc:id":"TD.TA",
+        "iso:code":"TD-TA",
         "iso:id":"TD-TA",
         "qs_pg:id":209010,
         "unlc:id":"TD-TA",
         "wd:id":"Q867856",
         "wk:page":"Tandjil\u00e9 Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"22f9041b2b8fd1cadae22c83351251d1",
+    "wof:geomhash":"f192baa9c736ecdb3a5e52252f6418cd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -314,7 +316,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1690868565,
+    "wof:lastmodified":1695884598,
     "wof:name":"Tandjil\u00e9",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/784/83/85678483.geojson
+++ b/data/856/784/83/85678483.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.430156,
-    "geom:area_square_m":17480215475.959694,
+    "geom:area_square_m":17480212546.477516,
     "geom:bbox":"17.048966,7.826356,18.213233,9.651271",
     "geom:latitude":8.698561,
     "geom:longitude":17.605192,
@@ -287,15 +287,17 @@
         "gn:id":7603252,
         "gp:id":56013482,
         "hasc:id":"TD.MA",
+        "iso:code":"TD-MA",
         "iso:id":"TD-MA",
         "qs_pg:id":1321042,
         "wd:id":"Q597410"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"322386d2fc4623439d7819153961751b",
+    "wof:geomhash":"b4d61130874f293e88a7e746884b0cf2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -312,7 +314,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1690868565,
+    "wof:lastmodified":1695884882,
     "wof:name":"Mandoul",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/784/87/85678487.geojson
+++ b/data/856/784/87/85678487.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.686414,
-    "geom:area_square_m":69061790832.594635,
+    "geom:area_square_m":69061788668.054123,
     "geom:bbox":"18.873966,9.081695,22.46228,12.122971",
     "geom:latitude":10.804348,
     "geom:longitude":20.594212,
@@ -291,17 +291,19 @@
         "gn:id":242048,
         "gp:id":2344957,
         "hasc:id":"TD.SA",
+        "iso:code":"TD-SA",
         "iso:id":"TD-SA",
         "qs_pg:id":1168629,
         "unlc:id":"TD-SA",
         "wd:id":"Q385584",
         "wk:page":"Salamat Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4bbe75e6dca861b636f62163dcd8f8d6",
+    "wof:geomhash":"622ccb3ec611dbd3b1454b1274ca61b1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -318,7 +320,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1690868564,
+    "wof:lastmodified":1695884882,
     "wof:name":"Salamat",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/784/91/85678491.geojson
+++ b/data/856/784/91/85678491.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029071,
-    "geom:area_square_m":351467497.471107,
+    "geom:area_square_m":351467497.471111,
     "geom:bbox":"14.890076,11.983093,15.160095,12.224954",
     "geom:latitude":12.114988,
     "geom:longitude":15.037736,
@@ -496,9 +496,11 @@
         "gn:id":7603254,
         "gp:id":56013485,
         "hasc:id":"TD.NJ",
+        "iso:code":"TD-ND",
         "iso:id":"TD-ND",
         "qs_pg:id":1199732
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         890440301,
         421193929
@@ -507,7 +509,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"eeeeb4e8078d68c730b3d2a47abadb6d",
+    "wof:geomhash":"17f660efcbc5303274f067fb6a0af0ad",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -524,7 +526,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1614893134,
+    "wof:lastmodified":1695884486,
     "wof:name":"N'Djamena",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/784/95/85678495.geojson
+++ b/data/856/784/95/85678495.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.078474,
-    "geom:area_square_m":13159331803.827642,
+    "geom:area_square_m":13159325910.502439,
     "geom:bbox":"13.957092,8.430488,15.468566,9.998474",
     "geom:latitude":9.318071,
     "geom:longitude":14.756707,
@@ -298,17 +298,19 @@
         "gn:id":7603253,
         "gp:id":56013484,
         "hasc:id":"TD.MW",
+        "iso:code":"TD-MO",
         "iso:id":"TD-MO",
         "qs_pg:id":77659,
         "unlc:id":"TD-MO",
         "wd:id":"Q910393",
         "wk:page":"Mayo-Kebbi Ouest Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"aa33bf14b6b588203df71d40665b3aed",
+    "wof:geomhash":"a4cddce30b4530d2a2e3a5fcb6e05b88",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -325,7 +327,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1690868562,
+    "wof:lastmodified":1695884881,
     "wof:name":"Mayo-Kebbi Ouest",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/785/01/85678501.geojson
+++ b/data/856/785/01/85678501.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":22.291546,
-    "geom:area_square_m":261458934098.172485,
+    "geom:area_square_m":261458926966.095886,
     "geom:bbox":"15.416687,15.313971,21.028366,22.075429",
     "geom:latitude":18.373696,
     "geom:longitude":18.528062,
@@ -165,14 +165,16 @@
         "gn:id":7602866,
         "gp:id":-2344947,
         "hasc:id":"TD.BR",
+        "iso:code":"TD-BO",
         "iso:id":"TD-BO",
         "wd:id":"Q4272710"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ef0724c8af10377fedd3aa7c9905ce52",
+    "wof:geomhash":"0ac0f3594733d673501a92edf160e9d5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -189,7 +191,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1690868561,
+    "wof:lastmodified":1695884881,
     "wof:name":"Borkou",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/785/05/85678505.geojson
+++ b/data/856/785/05/85678505.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":10.803701,
-    "geom:area_square_m":124506379099.530441,
+    "geom:area_square_m":124506365441.715698,
     "geom:bbox":"14.979466,17.084473,18.999388,23.493571",
     "geom:latitude":21.226548,
     "geom:longitude":16.638059,
@@ -158,13 +158,15 @@
         "gn:id":7603258,
         "gp:id":-2344947,
         "hasc:id":"TD.TI",
+        "iso:code":"TD-TI",
         "iso:id":"TD-TI"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8a48abe213aa1eb8f6bdf602d0516eea",
+    "wof:geomhash":"5a4131270ec5a953ca17e5b0b986b994",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -181,7 +183,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1636501289,
+    "wof:lastmodified":1695884881,
     "wof:name":"Tibesti",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/785/13/85678513.geojson
+++ b/data/856/785/13/85678513.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.81853,
-    "geom:area_square_m":46308304591.295074,
+    "geom:area_square_m":46308294462.866348,
     "geom:bbox":"15.01709,9.829171,17.542966,12.431971",
     "geom:latitude":11.241186,
     "geom:longitude":16.325053,
@@ -235,14 +235,16 @@
         "fips:code":"CD15",
         "gp:id":2344948,
         "hasc:id":"TD.CG",
+        "iso:code":"TD-CB",
         "iso:id":"TD-CB",
         "wd:id":"Q843975"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9b19381bc3edf5f755fdc48495fcdd6f",
+    "wof:geomhash":"201398758068cbad1b3281b3675461e3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -259,7 +261,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1690868562,
+    "wof:lastmodified":1695884882,
     "wof:name":"Chari-Baguirmi",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/785/19/85678519.geojson
+++ b/data/856/785/19/85678519.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.717393,
-    "geom:area_square_m":56455326037.879623,
+    "geom:area_square_m":56455318044.487457,
     "geom:bbox":"15.602112,13.022971,18.050966,16.243103",
     "geom:latitude":14.548839,
     "geom:longitude":16.878445,
@@ -239,14 +239,16 @@
         "gn:id":7603255,
         "gp:id":-2344950,
         "hasc:id":"TD.BG",
+        "iso:code":"TD-BG",
         "iso:id":"TD-BG",
         "wd:id":"Q803639"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ef03a54bba9eab24f2b4f47296659dd6",
+    "wof:geomhash":"43e3821cf74ed0ed1e1f02c2d5b07c73",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -263,7 +265,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1690868561,
+    "wof:lastmodified":1695884363,
     "wof:name":"Barh-El-Gazel",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/785/23/85678523.geojson
+++ b/data/856/785/23/85678523.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.968814,
-    "geom:area_square_m":35888064272.755035,
+    "geom:area_square_m":35888073140.368462,
     "geom:bbox":"19.888966,10.921082,22.975098,13.058971",
     "geom:latitude":12.13888,
     "geom:longitude":21.443274,
@@ -431,15 +431,17 @@
         "gn:id":7603257,
         "gp:id":-2344956,
         "hasc:id":"TD.SI",
+        "iso:code":"TD-SI",
         "iso:id":"TD-SI",
         "unlc:id":"TD-SI",
         "wd:id":"Q359465"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f9ec3355d2dbb15274425ff2f625a54b",
+    "wof:geomhash":"fc135d338aafeac459e459d5ba1e30f3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -456,7 +458,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1690868562,
+    "wof:lastmodified":1695884363,
     "wof:name":"Sila",
     "wof:parent_id":85632325,
     "wof:placetype":"region",

--- a/data/856/785/27/85678527.geojson
+++ b/data/856/785/27/85678527.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.424422,
-    "geom:area_square_m":41769523691.086136,
+    "geom:area_square_m":41769520061.273476,
     "geom:bbox":"17.381966,8.021118,19.990258,10.587971",
     "geom:latitude":9.428047,
     "geom:longitude":18.649694,
@@ -340,15 +340,17 @@
         "gn:id":2427315,
         "gp:id":-56013482,
         "hasc:id":"TD.MO",
+        "iso:code":"TD-MC",
         "iso:id":"TD-MC",
         "unlc:id":"TD-MC",
         "wd:id":"Q6927631"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e0d5433c643e1cee3a26d907980a2eef",
+    "wof:geomhash":"75024d0108acfba9be225a330d1b23d9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -365,7 +367,7 @@
         "fra",
         "ara"
     ],
-    "wof:lastmodified":1636501290,
+    "wof:lastmodified":1695884882,
     "wof:name":"Moyen-Chari",
     "wof:parent_id":85632325,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.